### PR TITLE
Fix reporting of the URL from window thats not current #17

### DIFF
--- a/postfactum.js
+++ b/postfactum.js
@@ -4,7 +4,7 @@ const PostFactum = {
     return `${config.baseUrl}/api/v1/source_articles/submit/`;
   },
   sendRequest: async function (vote) {
-    const [tab] = await chrome.tabs.query({ active: true });
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
     const data = {
       vote,
       url: tab.url,


### PR DESCRIPTION
* Bug can be replicated by opening 2 windows in Chrome.
* Try to upvote or downvote from second, it will report the first window URL.

Now it should be fixed.